### PR TITLE
Feature flywheel subsystem

### DIFF
--- a/PolySTAR-Taproot-project/src/control/standard/standard_control.cpp
+++ b/PolySTAR-Taproot-project/src/control/standard/standard_control.cpp
@@ -19,6 +19,10 @@
 #include "subsystems/feeder/feeder_feed_command.hpp"
 #include "subsystems/feeder/feeder_reverse_command.hpp"
 
+// Flywheel includes
+#include "subsystems/flywheel/flywheel_subsystem.hpp"
+#include "subsystems/flywheel/flywheel_fire_command.hpp"
+
 using src::DoNotUse_getDrivers;
 using src::control::RemoteSafeDisconnectFunction;
 using tap::communication::serial::Remote;
@@ -40,6 +44,7 @@ namespace control
 chassis::ChassisSubsystem theChassis(drivers());
 turret::TurretSubsystem theTurret(drivers());
 feeder::FeederSubsystem theFeeder(drivers());
+flywheel::FlywheelSubsystem theFlywheel(drivers());
 
 /* define commands ----------------------------------------------------------*/
 chassis::ChassisDriveCommand chassisDrive(&theChassis, drivers());
@@ -48,6 +53,7 @@ turret::TurretManualAimCommand turretManualAim(&theTurret, drivers());
 turret::TurretDebugCommand turretDebug(&theTurret, drivers());
 feeder::FeederFeedCommand feederForward(&theFeeder, drivers());
 feeder::FeederReverseCommand feederReverse(&theFeeder, drivers());
+flywheel::FlywheelFireCommand flywheelFire(&theFlywheel, drivers());
 
 /* safe disconnect function -------------------------------------------------*/
 RemoteSafeDisconnectFunction remoteSafeDisconnectFunction(drivers());
@@ -56,12 +62,14 @@ RemoteSafeDisconnectFunction remoteSafeDisconnectFunction(drivers());
 HoldCommandMapping feedFeeder(drivers(), {&feederForward}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
 HoldCommandMapping reverseFeeder(drivers(), {&feederReverse}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
 HoldCommandMapping debugTurret(drivers(), {&turretDebug}, RemoteMapState(Remote::Switch::LEFT_SWITCH, Remote::SwitchState::UP));
+HoldCommandMapping fireFlywheel(drivers(), {&flywheelFire}, RemoteMapState(Remote::Switch::LEFT_SWITCH, Remote::SwitchState::UP));
 
 /* register subsystems here -------------------------------------------------*/
 void registerStandardSubsystems(src::Drivers *drivers) {
     drivers->commandScheduler.registerSubsystem(&theChassis);
     drivers->commandScheduler.registerSubsystem(&theTurret);
     drivers->commandScheduler.registerSubsystem(&theFeeder);
+    drivers->commandScheduler.registerSubsystem(&theFlywheel);
 }
 
 /* initialize subsystems ----------------------------------------------------*/
@@ -69,6 +77,7 @@ void initializeSubsystems() {
     theChassis.initialize();
     theTurret.initialize();
     theFeeder.initialize();
+    theFlywheel.initialize();
 }
 
 /* set any default commands to subsystems here ------------------------------*/
@@ -87,6 +96,7 @@ void registerStandardIoMappings(src::Drivers *drivers) {
    drivers->commandMapper.addMap(&feedFeeder);
    drivers->commandMapper.addMap(&reverseFeeder);
    drivers->commandMapper.addMap(&debugTurret);
+   drivers->commandMapper.addMap(&fireFlywheel);
 }
 
 void initSubsystemCommands(src::Drivers *drivers)

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
@@ -1,10 +1,7 @@
 #ifndef FLYWHEEL_CONSTANTS_HPP_
 #define FLYWHEEL_CONSTANTS_HPP_
 
-// Default flywheel velocity represented as a PWM duty cycle between 0 and 1
-constexpr static float DEFAULT_FLYWHEEL_VEL = 0.5;
-
-// Snail velocity ramp rate in percent per millisecond
-const float SNAIL_RAMP_RATE = 100;
+// Default flywheel velocity represented as a throttle value between 0 and 1
+constexpr static float FLYWHEEL_DEFAULT_THROTTLE = 0.5;
 
 #endif

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
@@ -1,0 +1,10 @@
+#ifndef FLYWHEEL_CONSTANTS_HPP_
+#define FLYWHEEL_CONSTANTS_HPP_
+
+// Default flywheel velocity represented as a PWM duty cycle between 0 and 1
+constexpr static float DEFAULT_FLYWHEEL_VEL = 0.5;
+
+// Snail velocity ramp rate in percent per millisecond
+const float SNAIL_RAMP_RATE = 100;
+
+#endif

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_constants.hpp
@@ -3,5 +3,6 @@
 
 // Default flywheel velocity represented as a throttle value between 0 and 1
 constexpr static float FLYWHEEL_DEFAULT_THROTTLE = 0.5;
+const float END_VALUE = 0.0;
 
 #endif

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
@@ -11,14 +11,19 @@ namespace control
 {
 namespace flywheel
 {
+
+FlywheelFireCommand::FlywheelFireCommand (FlywheelSubsystem *const flywheel, tap::Drivers *drivers): { 
+    this.flywheel = flywheel;
+}
+
 void FlywheelFireCommand::initialize()
 {
-    snailMotor.init();
+    flywheel.startFiring();
 }
 
 void FlywheelFireCommand::end(bool)
 {   
-    snailMotor.setThrottle(END_VALUE);
+    flywheel.stopFiring();
 }
 
 void FlywheelFireCommand::execute ()

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
@@ -1,0 +1,27 @@
+#include "flywheel_fire_command.hpp"
+
+#include "tap/communication/serial/remote.hpp"
+#include "tap/algorithms/math_user_utils.hpp"
+#include "control/drivers/drivers.hpp"
+
+using namespace tap;
+using tap::communication::serial::Uart;
+
+namespace control
+{
+namespace flywheel
+{
+void FlywheelFireCommand::initialize()
+{
+    snailMotor.init();
+}
+
+void FlywheelFireCommand::end()
+{   
+    snailMotor.setThrottle(END_VALUE);
+}
+
+}  // namespace flywheel
+
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.cpp
@@ -16,10 +16,12 @@ void FlywheelFireCommand::initialize()
     snailMotor.init();
 }
 
-void FlywheelFireCommand::end()
+void FlywheelFireCommand::end(bool)
 {   
     snailMotor.setThrottle(END_VALUE);
 }
+
+void FlywheelFireCommand::execute ()
 
 }  // namespace flywheel
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
@@ -22,17 +22,13 @@ public:
      * Constructs a new FlywheelSubsystem with default parameters specified in
      * the private section of this class.
      */
-    FlywheelFireCommand(tap::Drivers *drivers)
-        : tap::control::Command(),
-          snailMotor(drivers, FLYWHEEL_PWM_PIN),
-          currentThrottle(FLYWHEEL_DEFAULT_THROTTLE),
-          firing(false)
+    FlywheelFireCommand(FlywheelSubsystem *const flywheel, tap::Drivers *drivers)
     {
     }
 
     void initialize() override;
-    
-    void end() override;
+
+    void end(bool) override;
 
     const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
@@ -1,0 +1,54 @@
+#ifndef FLYWHEEL_SUBSYSTEM_HPP_
+#define FLYWHEEL_SUBSYSTEM_HPP_
+
+#include "tap/control/command.hpp"
+#include "snail_motor.hpp"
+#include "tap/util_macros.hpp"
+#include "flywheel_constants.hpp"
+#include "flywheel_subsystem.hpp"
+
+namespace control
+{
+namespace flywheel
+{
+/**
+ * A bare bones Subsystem for interacting with a flywheel.
+ */
+class FlywheelFireCommand : public tap::control::Command
+{
+public:
+
+    /**
+     * Constructs a new FlywheelSubsystem with default parameters specified in
+     * the private section of this class.
+     */
+    FlywheelFireCommand(tap::Drivers *drivers)
+        : tap::control::Command(),
+          snailMotor(drivers, FLYWHEEL_PWM_PIN),
+          currentThrottle(FLYWHEEL_DEFAULT_THROTTLE),
+          firing(false)
+    {
+    }
+
+    void initialize() override;
+    
+    void end() override;
+
+    const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
+
+private:
+    // Hardware constants, not specific to any particular flywheel subsystem.
+    static constexpr tap::gpio::Pwm::Pin FLYWHEEL_PWM_PIN = tap::gpio::Pwm::Pin::Z;
+
+    src::motor::SnailMotor snailMotor;
+
+    float currentThrottle;
+
+    float firing;
+};  // class FlywheelSubsystem
+
+}  // namespace flywheel
+
+}  // namespace control
+
+#endif  // FLYWHEEL_SUBSYSTEM_HPP_

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
@@ -1,5 +1,6 @@
-#ifndef FLYWHEEL_SUBSYSTEM_HPP_
-#define FLYWHEEL_SUBSYSTEM_HPP_
+#ifndef FLYWHEEL_SUBSYSTEM_COMMAND_HPP_
+#define FLYWHEEL_SUBSYSTEM_COMMAND_HPP_
+
 
 #include "tap/control/command.hpp"
 #include "snail_motor.hpp"
@@ -29,6 +30,12 @@ public:
     void initialize() override;
 
     void end(bool) override;
+
+    const char *getName () const { return "flywheel"; }
+
+    void execute() override;
+
+    bool isFinished() const { return false; } 
 
     const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_fire_command.hpp
@@ -12,20 +12,12 @@ namespace control
 {
 namespace flywheel
 {
-/**
- * A bare bones Subsystem for interacting with a flywheel.
- */
+
 class FlywheelFireCommand : public tap::control::Command
 {
 public:
 
-    /**
-     * Constructs a new FlywheelSubsystem with default parameters specified in
-     * the private section of this class.
-     */
-    FlywheelFireCommand(FlywheelSubsystem *const flywheel, tap::Drivers *drivers)
-    {
-    }
+    FlywheelFireCommand(FlywheelSubsystem *const flywheel, tap::Drivers *drivers) {}
 
     void initialize() override;
 
@@ -35,23 +27,16 @@ public:
 
     void execute() override;
 
-    bool isFinished() const { return false; } 
-
-    const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
+    bool isFinished() const { return false; }
 
 private:
     // Hardware constants, not specific to any particular flywheel subsystem.
-    static constexpr tap::gpio::Pwm::Pin FLYWHEEL_PWM_PIN = tap::gpio::Pwm::Pin::Z;
+    FlywheelSubsystem flywheel;
 
-    src::motor::SnailMotor snailMotor;
-
-    float currentThrottle;
-
-    float firing;
-};  // class FlywheelSubsystem
+};  // class FlywheelFireCommand
 
 }  // namespace flywheel
 
 }  // namespace control
 
-#endif  // FLYWHEEL_SUBSYSTEM_HPP_
+#endif  // FLYWHEEL_SUBSYSTEM_COMMAND_HPP_

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
@@ -1,0 +1,38 @@
+#include "flywheel_subsystem.hpp"
+
+#include "tap/communication/serial/remote.hpp"
+#include "tap/algorithms/math_user_utils.hpp"
+#include "control/drivers/drivers.hpp"
+
+using namespace tap;
+using tap::communication::serial::Uart;
+
+namespace control
+{
+namespace flywheel
+{
+void FlywheelSubsystem::initialize()
+{
+
+}
+
+void FlywheelSubsystem::refresh() {
+    flywheelMotor.updateSendPwm();
+}
+
+void FlywheelSubsystem::startFiring() {
+    flywheelMotor.start();
+}
+
+void FlywheelSubsystem::stopFiring() {
+    flywheelMotor.stop();
+}
+
+void FlywheelSubsystem::updateFireVel(float targetFireVelocity) {
+    flywheelMotor.setTargetSpeed(targetFireVelocity);
+}
+
+}  // namespace flywheel
+
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
@@ -25,7 +25,7 @@ void FlywheelSubsystem::startFiring() {
 }
 
 void FlywheelSubsystem::stopFiring() {
-    snailMotor.setThrottle(0);
+    snailMotor.setThrottle(END_VALUE);
 }
 
 void FlywheelSubsystem::setThrottle(float throttle) {

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.cpp
@@ -13,23 +13,31 @@ namespace flywheel
 {
 void FlywheelSubsystem::initialize()
 {
-
+    snailMotor.init();
 }
 
 void FlywheelSubsystem::refresh() {
-    flywheelMotor.updateSendPwm();
+
 }
 
 void FlywheelSubsystem::startFiring() {
-    flywheelMotor.start();
+    snailMotor.setThrottle(currentThrottle);
 }
 
 void FlywheelSubsystem::stopFiring() {
-    flywheelMotor.stop();
+    snailMotor.setThrottle(0);
 }
 
-void FlywheelSubsystem::updateFireVel(float targetFireVelocity) {
-    flywheelMotor.setTargetSpeed(targetFireVelocity);
+void FlywheelSubsystem::setThrottle(float throttle) {
+    currentThrottle = throttle;
+
+    if (firing == false) return;
+
+    startFiring();
+}
+
+float FlywheelSubsystem::getCurrentThrottle() const {
+    return currentThrottle;
 }
 
 }  // namespace flywheel

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
@@ -47,6 +47,8 @@ public:
 
     float getCurrentThrottle() const;
 
+    void flywheelCommandFire()
+
     const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
 
 private:

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
@@ -23,7 +23,9 @@ public:
      */
     FlywheelSubsystem(tap::Drivers *drivers)
         : tap::control::Subsystem(drivers),
-          flywheelMotor(drivers, FLYWHEEL_PWM_PIN, DEFAULT_FLYWHEEL_VEL, SNAIL_RAMP_RATE)
+          snailMotor(drivers, FLYWHEEL_PWM_PIN),
+          currentThrottle(FLYWHEEL_DEFAULT_THROTTLE),
+          firing(false)
     {
     }
 
@@ -41,16 +43,21 @@ public:
 
     void stopFiring();
 
-    void updateFireVel(float targetFireVelocity);
+    void setThrottle(float throttle);
 
-    const src::motor::SnailMotor &getFlywheelMotor() const { return flywheelMotor; }
+    float getCurrentThrottle() const;
+
+    const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
 
 private:
     // Hardware constants, not specific to any particular flywheel subsystem.
     static constexpr tap::gpio::Pwm::Pin FLYWHEEL_PWM_PIN = tap::gpio::Pwm::Pin::Z;
 
-    // Servo interface used for the PWM to communicate to Snail ESC
-    src::motor::SnailMotor flywheelMotor;
+    src::motor::SnailMotor snailMotor;
+
+    float currentThrottle;
+
+    float firing;
 };  // class FlywheelSubsystem
 
 }  // namespace flywheel

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
@@ -47,7 +47,7 @@ public:
 
     float getCurrentThrottle() const;
 
-    void flywheelCommandFire()
+    void flywheelCommandFire();
 
     const src::motor::SnailMotor &getFlywheelMotor() const { return snailMotor; }
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/flywheel_subsystem.hpp
@@ -1,0 +1,60 @@
+#ifndef FLYWHEEL_SUBSYSTEM_HPP_
+#define FLYWHEEL_SUBSYSTEM_HPP_
+
+#include "tap/control/subsystem.hpp"
+#include "snail_motor.hpp"
+#include "tap/util_macros.hpp"
+#include "flywheel_constants.hpp"
+
+namespace control
+{
+namespace flywheel
+{
+/**
+ * A bare bones Subsystem for interacting with a flywheel.
+ */
+class FlywheelSubsystem : public tap::control::Subsystem
+{
+public:
+
+    /**
+     * Constructs a new FlywheelSubsystem with default parameters specified in
+     * the private section of this class.
+     */
+    FlywheelSubsystem(tap::Drivers *drivers)
+        : tap::control::Subsystem(drivers),
+          flywheelMotor(drivers, FLYWHEEL_PWM_PIN, DEFAULT_FLYWHEEL_VEL, SNAIL_RAMP_RATE)
+    {
+    }
+
+    FlywheelSubsystem(const FlywheelSubsystem &other) = delete;
+
+    FlywheelSubsystem &operator=(const FlywheelSubsystem &other) = delete;
+
+    ~FlywheelSubsystem() = default;
+
+    void initialize() override;
+
+    void refresh() override;
+
+    void startFiring();
+
+    void stopFiring();
+
+    void updateFireVel(float targetFireVelocity);
+
+    const src::motor::SnailMotor &getFlywheelMotor() const { return flywheelMotor; }
+
+private:
+    // Hardware constants, not specific to any particular flywheel subsystem.
+    static constexpr tap::gpio::Pwm::Pin FLYWHEEL_PWM_PIN = tap::gpio::Pwm::Pin::Z;
+
+    // Servo interface used for the PWM to communicate to Snail ESC
+    src::motor::SnailMotor flywheelMotor;
+};  // class FlywheelSubsystem
+
+}  // namespace flywheel
+
+}  // namespace control
+
+#endif  // FLYWHEEL_SUBSYSTEM_HPP_

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
@@ -1,0 +1,36 @@
+#include "snail_motor.hpp"
+
+namespace src
+{
+namespace motor
+{
+SnailMotor::SnailMotor(
+    tap::Drivers *drivers,
+    tap::gpio::Pwm::Pin pwmPin,
+    float firingSpeed,
+    float rampRate)
+    : tap::motor::Servo(drivers, pwmPin, 1, 0, rampRate),
+      firingSpeed(firingSpeed)
+{
+}
+
+void SnailMotor::start() {
+    Servo::setTargetPwm(firingSpeed);
+}
+
+void SnailMotor::setTargetSpeed(float targetFiringSpeed) {
+    firingSpeed = targetFiringSpeed;
+    Servo::setTargetPwm(firingSpeed);
+}
+
+void SnailMotor::stop() {
+    Servo::setTargetPwm(0);
+}
+
+void SnailMotor::updateSendPwm() {
+    Servo::updateSendPwmRamp();
+}
+
+}  // namespace motor
+
+}  // namespace src

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
@@ -1,34 +1,28 @@
 #include "snail_motor.hpp"
 
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/architecture/clock.hpp"
+#include "tap/drivers.hpp"
+
 namespace src
 {
 namespace motor
 {
 SnailMotor::SnailMotor(
     tap::Drivers *drivers,
-    tap::gpio::Pwm::Pin pwmPin,
-    float firingSpeed,
-    float rampRate)
-    : tap::motor::Servo(drivers, pwmPin, 1, 0, rampRate),
-      firingSpeed(firingSpeed)
+    tap::gpio::Pwm::Pin pwmPin) 
+    : drivers(drivers),
+      pwmPin(pwmPin)
 {
 }
 
-void SnailMotor::start() {
-    Servo::setTargetPwm(firingSpeed);
+void SnailMotor::init() {
+    drivers->pwm.setTimerFrequency(tap::gpio::Pwm::Timer::TIMER8, 500);
 }
 
-void SnailMotor::setTargetSpeed(float targetFiringSpeed) {
-    firingSpeed = targetFiringSpeed;
-    Servo::setTargetPwm(firingSpeed);
-}
-
-void SnailMotor::stop() {
-    Servo::setTargetPwm(0);
-}
-
-void SnailMotor::updateSendPwm() {
-    Servo::updateSendPwmRamp();
+void SnailMotor::setThrottle(float throttle) {
+    float pwmDutyCycle = THROTTLE_IDLE + throttle*THROTTLE_RANGE;
+    drivers->pwm.write(pwmDutyCycle, pwmPin);
 }
 
 }  // namespace motor

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
@@ -1,48 +1,49 @@
 #ifndef SNAIL_MOTOR_HPP_
 #define SNAIL_MOTOR_HPP_
 
-
-#include "tap/motor/servo.hpp"
+#include "tap/drivers.hpp"
+#include "tap/communication/gpio/pwm.hpp"
 
 namespace src
 {
-class Drivers;
 namespace motor
 {
 /**
  * This class wraps around the Servo class to provide utilities for controlling a Robomaster Snail motor.
  */
-class SnailMotor : tap::motor::Servo
+class SnailMotor
 {
 public:
     /**
      * Initializes the Snail PWM and associates the motor with some PWM pin.
+     * THIS WILL ONLY WORK IF PWM IS SET TO 500Hz OR LESS (see snail esc datasheet)
      *
      * @param[in] drivers Instance to the drivers class you would like to use.
-     * @param[in] pwmPin The pin to attach the Servo class with.
-     * @param[in] firingSpeed Firing speed between 0 and 1. No associated unit.
+     * @param[in] pwmPin The pin to attach the Snail Motor class with.
      */
     SnailMotor(
         tap::Drivers *drivers,
-        tap::gpio::Pwm::Pin pwmPin,
-        float firingSpeed,
-        float rampRate);
+        tap::gpio::Pwm::Pin pwmPin);
+
+    void init();
 
     /**
-     * Updates the `pwmOutputRamp` object and then sets the output PWM to the updated
-     * ramp value.
+     * Sets the throttle value sent to the Snail ESC.
+     * 0-1, where 0 is idle and 1 is full throttle
      */
-    void updateSendPwm();
-
-    void start();
-
-    void setTargetSpeed(float targetFiringSpeed);
-
-    void stop();
+    void setThrottle(float throttle);
 
 private:
-    // Target PWM duty cycle sent to the snail ESC.
-    float firingSpeed;
+    tap::Drivers *drivers;
+
+    /// The PWM pin that the servo is attached to.
+    tap::gpio::Pwm::Pin pwmPin;
+
+    // Duty cycle values for pulse widths
+    // Idle throttle 1ms -> 50% duty cycle at 500Hz
+    // Full throttle 2ms -> 100% duty cycle at 500Hz
+    const float THROTTLE_IDLE = 0.5;
+    const float THROTTLE_RANGE = 0.5;
 
 };  // class SnailMotor
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
@@ -1,0 +1,53 @@
+#ifndef SNAIL_MOTOR_HPP_
+#define SNAIL_MOTOR_HPP_
+
+
+#include "tap/motor/servo.hpp"
+
+namespace src
+{
+class Drivers;
+namespace motor
+{
+/**
+ * This class wraps around the Servo class to provide utilities for controlling a Robomaster Snail motor.
+ */
+class SnailMotor : tap::motor::Servo
+{
+public:
+    /**
+     * Initializes the Snail PWM and associates the motor with some PWM pin.
+     *
+     * @param[in] drivers Instance to the drivers class you would like to use.
+     * @param[in] pwmPin The pin to attach the Servo class with.
+     * @param[in] firingSpeed Firing speed between 0 and 1. No associated unit.
+     */
+    SnailMotor(
+        tap::Drivers *drivers,
+        tap::gpio::Pwm::Pin pwmPin,
+        float firingSpeed,
+        float rampRate);
+
+    /**
+     * Updates the `pwmOutputRamp` object and then sets the output PWM to the updated
+     * ramp value.
+     */
+    void updateSendPwm();
+
+    void start();
+
+    void setTargetSpeed(float targetFiringSpeed);
+
+    void stop();
+
+private:
+    // Target PWM duty cycle sent to the snail ESC.
+    float firingSpeed;
+
+};  // class SnailMotor
+
+}  // namespace motor
+
+}  // namespace src
+
+#endif  // SNAIL_MOTOR_HPP_


### PR DESCRIPTION
Implement the flywheel subsystem.

Also adds a new SnailMotor class, that uses PWM to control the Snail ESC.
Calling `SnailMotor::init()` sets the PWM frequency for PWM pins Z, Y, X and W on the Board A to 500Hz. This is a necessary side effect as all four pins are connected to the same hardware timer.