### PR TITLE
Referee system feedback 

### DIFF
--- a/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
+++ b/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
@@ -91,7 +91,7 @@ ToggleCommandMapping turretMouseAimToggle(drivers(), {&turretMouseAim}, RemoteMa
 ToggleCommandMapping toggleChassisDrive(drivers(), {&chassisKeyboardDrive}, RemoteMapState({Remote::Key::G}));
 // ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive}, RemoteMapState({Remote::Key::R}));
 ToggleCommandMapping toggleAutoCommands(drivers(), {&chassisAutoDrive, &turretAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
-ToggleCommandMapping toggleTestCommands(drivers(), {&chassisTestAutoDrive, &turretTestAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
+ToggleCommandMapping toggleAutoTestCommands(drivers(), {&chassisTestAutoDrive, &turretTestAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
 
 
 /*-Only used for calibration-*/
@@ -137,7 +137,7 @@ void registerStandardIoMappings(src::Drivers *drivers) {
     drivers->commandMapper.addMap(&turretMouseAimToggle);
     /*-Chassis-*/
     drivers->commandMapper.addMap(&toggleChassisDrive);
-    drivers->commandMapper.addMap(&toggleTestCommands);
+    drivers->commandMapper.addMap(&toggleAutoTestCommands);
     drivers->commandMapper.addMap(&toggleAutoCommands);
 
 }

--- a/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
+++ b/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
@@ -60,6 +60,7 @@ flywheel::FlywheelSubsystem theFlywheel(drivers());
 /* define commands ----------------------------------------------------------*/
 chassis::ChassisDriveCommand chassisDrive(&theChassis, drivers());
 chassis::ChassisAutoDriveCommand chassisAutoDrive(&theChassis, drivers());
+chassis::ChassisTestDriveCommand chassisTestAutoDrive(&theChassis, drivers());
 chassis::ChassisKeyboardDriveCommand chassisKeyboardDrive(&theChassis, drivers());
 chassis::ChassisCalibrateImuCommand chassisImuCalibrate(&theChassis, drivers());
 
@@ -67,6 +68,8 @@ turret::TurretManualAimCommand turretManualAim(&theTurret, drivers());
 turret::TurretLeftAimCommand turretLeftAim(&theTurret, drivers());
 turret::TurretRightAimCommand turretRightAim(&theTurret, drivers());
 turret::TurretMouseAimCommand turretMouseAim(&theTurret, drivers());
+turret::TurretAutoAimCommand turretAutoAim(&theTurret, drivers());
+turret::TurretTestAutoAimCommand turretTestAutoAim(&theTurret, drivers());
 
 feeder::FeederMoveUnjamCommand feederMoveUnjam(&theFeeder, drivers());
 
@@ -86,7 +89,9 @@ HoldCommandMapping leftAimTurret(drivers(), {&turretLeftAim}, RemoteMapState(Rem
 ToggleCommandMapping turretMouseAimToggle(drivers(), {&turretMouseAim}, RemoteMapState({Remote::Key::B}));
 /*-Chassis-*/
 ToggleCommandMapping toggleChassisDrive(drivers(), {&chassisKeyboardDrive}, RemoteMapState({Remote::Key::G}));
-ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive}, RemoteMapState({Remote::Key::R}));
+// ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive}, RemoteMapState({Remote::Key::R}));
+ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive, &turretAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
+ToggleCommandMapping toggleChassisTestAuto(drivers(), {&chassisTestAutoDrive, &turretTestAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
 
 
 /*-Only used for calibration-*/

--- a/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
+++ b/PolySTAR-Taproot-project/src/control/Icra/icra_control.cpp
@@ -90,8 +90,8 @@ ToggleCommandMapping turretMouseAimToggle(drivers(), {&turretMouseAim}, RemoteMa
 /*-Chassis-*/
 ToggleCommandMapping toggleChassisDrive(drivers(), {&chassisKeyboardDrive}, RemoteMapState({Remote::Key::G}));
 // ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive}, RemoteMapState({Remote::Key::R}));
-ToggleCommandMapping toggleChassisAuto(drivers(), {&chassisAutoDrive, &turretAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
-ToggleCommandMapping toggleChassisTestAuto(drivers(), {&chassisTestAutoDrive, &turretTestAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
+ToggleCommandMapping toggleAutoCommands(drivers(), {&chassisAutoDrive, &turretAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
+ToggleCommandMapping toggleTestCommands(drivers(), {&chassisTestAutoDrive, &turretTestAutoAim}, RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::DOWN));
 
 
 /*-Only used for calibration-*/
@@ -137,7 +137,8 @@ void registerStandardIoMappings(src::Drivers *drivers) {
     drivers->commandMapper.addMap(&turretMouseAimToggle);
     /*-Chassis-*/
     drivers->commandMapper.addMap(&toggleChassisDrive);
-    drivers->commandMapper.addMap(&toggleChassisAuto);
+    drivers->commandMapper.addMap(&toggleTestCommands);
+    drivers->commandMapper.addMap(&toggleAutoCommands);
 
 }
 

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
@@ -26,6 +26,11 @@ void  ChassisAutoDriveCommand::initialize() {}
 
 void  ChassisAutoDriveCommand::execute()
 {
+    if (!IS_IN_TESTING && drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
+    {
+        chassis->setTargetOutput(0, 0, 0);
+        return;
+    }
     // Acquire setpoints received from CV over serial through CVHandler
     // And convert velocities to chassis inputs
     CVSerialData::Rx::MovementData movementData = drivers->cvHandler.getMovementData();

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
@@ -1,7 +1,5 @@
 #include "chassis_auto_drive_command.hpp"
 
-using src::communication::cv::CVSerialData;
-
 namespace control
 {
 namespace chassis

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
@@ -1,8 +1,5 @@
 #include "chassis_auto_drive_command.hpp"
 
-#include "tap/algorithms/math_user_utils.hpp"
-#include "tap/errors/create_errors.hpp"
-
 using src::communication::cv::CVSerialData;
 
 namespace control
@@ -12,17 +9,9 @@ namespace chassis
 ChassisAutoDriveCommand::ChassisAutoDriveCommand(
     ChassisSubsystem *const chassis,
     src::Drivers *drivers)
-    : chassis(chassis),
-      drivers(drivers)
+    : GenericAutoDriveCommand(chassis, drivers)
 {
-    if (chassis == nullptr)
-    {
-        return;
-    }
-    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(chassis));
 }
-
-void  ChassisAutoDriveCommand::initialize() {}
 
 void  ChassisAutoDriveCommand::execute()
 {
@@ -31,20 +20,9 @@ void  ChassisAutoDriveCommand::execute()
         chassis->setTargetOutput(0, 0, 0);
         return;
     }
-    // Acquire setpoints received from CV over serial through CVHandler
-    // And convert velocities to chassis inputs
-    CVSerialData::Rx::MovementData movementData = drivers->cvHandler.getMovementData();
-    float x = movementData.xSetpoint*VX_TO_X;
-    float y = movementData.ySetpoint*VY_TO_Y;
-    float r = movementData.rSetpoint*W_TO_R;
-    chassis->setTargetOutput(x,y,r);
+    GenericAutoDriveCommand::execute();
 }
 
-void  ChassisAutoDriveCommand::end(bool) {
-    chassis->setTargetOutput(0,0,0);
-}
-
-bool  ChassisAutoDriveCommand::isFinished() const { return false; }
 }  // namespace chassis
 }  // namespace control
 

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.cpp
@@ -26,7 +26,7 @@ void  ChassisAutoDriveCommand::initialize() {}
 
 void  ChassisAutoDriveCommand::execute()
 {
-    if (!IS_IN_TESTING && drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
+    if (drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
     {
         chassis->setTargetOutput(0, 0, 0);
         return;

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_auto_drive_command.hpp
@@ -1,16 +1,13 @@
 #ifndef CHASSIS_AUTO_DRIVE_COMMAND_HPP_
 #define CHASSIS_AUTO_DRIVE_COMMAND_HPP_
 
-#include "tap/control/command.hpp"
-
-#include "chassis_subsystem.hpp"
-#include "control/drivers/drivers.hpp"
+#include "generic_auto_drive_command.hpp"
 
 namespace control
 {
 namespace chassis
 {
-class ChassisAutoDriveCommand : public tap::control::Command
+class ChassisAutoDriveCommand : public GenericAutoDriveCommand
 {
 public:
     /**
@@ -26,20 +23,10 @@ public:
 
     ChassisAutoDriveCommand &operator=(const ChassisAutoDriveCommand &other) = delete;
 
-    void initialize() override;
-
     const char *getName() const { return "chassis auto drive command"; }
 
     void execute() override;
 
-    void end(bool) override;
-
-    bool isFinished() const override;
-
-private:
-    ChassisSubsystem *const chassis;
-
-    src::Drivers *drivers;
 };  // ChassisAutoDriveCommand
 
 }  // namespace chassis

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
@@ -1,0 +1,45 @@
+#include "chassis_test_auto_drive_command.hpp"
+
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/errors/create_errors.hpp"
+
+using src::communication::cv::CVSerialData;
+
+namespace control
+{
+namespace chassis
+{
+ChassisTestAutoDriveCommand::ChassisTestAutoDriveCommand(
+    ChassisSubsystem *const chassis,
+    src::Drivers *drivers)
+    : chassis(chassis),
+      drivers(drivers)
+{
+    if (chassis == nullptr)
+    {
+        return;
+    }
+    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(chassis));
+}
+
+void  ChassisTestAutoDriveCommand::initialize() {}
+
+void  ChassisTestAutoDriveCommand::execute()
+{
+    // Acquire setpoints received from CV over serial through CVHandler
+    // And convert velocities to chassis inputs
+    CVSerialData::Rx::MovementData movementData = drivers->cvHandler.getMovementData();
+    float x = movementData.xSetpoint*VX_TO_X;
+    float y = movementData.ySetpoint*VY_TO_Y;
+    float r = movementData.rSetpoint*W_TO_R;
+    chassis->setTargetOutput(x,y,r);
+}
+
+void  ChassisTestAutoDriveCommand::end(bool) {
+    chassis->setTargetOutput(0,0,0);
+}
+
+bool  ChassisTestAutoDriveCommand::isFinished() const { return false; }
+}  // namespace chassis
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
@@ -1,8 +1,5 @@
 #include "chassis_test_auto_drive_command.hpp"
 
-#include "tap/algorithms/math_user_utils.hpp"
-#include "tap/errors/create_errors.hpp"
-
 using src::communication::cv::CVSerialData;
 
 namespace control
@@ -12,34 +9,14 @@ namespace chassis
 ChassisTestAutoDriveCommand::ChassisTestAutoDriveCommand(
     ChassisSubsystem *const chassis,
     src::Drivers *drivers)
-    : chassis(chassis),
-      drivers(drivers)
+    : GenericAutoDriveCommand(chassis, drivers)
 {
-    if (chassis == nullptr)
-    {
-        return;
-    }
-    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(chassis));
 }
-
-void  ChassisTestAutoDriveCommand::initialize() {}
 
 void  ChassisTestAutoDriveCommand::execute()
 {
-    // Acquire setpoints received from CV over serial through CVHandler
-    // And convert velocities to chassis inputs
-    CVSerialData::Rx::MovementData movementData = drivers->cvHandler.getMovementData();
-    float x = movementData.xSetpoint*VX_TO_X;
-    float y = movementData.ySetpoint*VY_TO_Y;
-    float r = movementData.rSetpoint*W_TO_R;
-    chassis->setTargetOutput(x,y,r);
+    GenericAutoDriveCommand::execute();
 }
-
-void  ChassisTestAutoDriveCommand::end(bool) {
-    chassis->setTargetOutput(0,0,0);
-}
-
-bool  ChassisTestAutoDriveCommand::isFinished() const { return false; }
 }  // namespace chassis
 }  // namespace control
 

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.cpp
@@ -1,6 +1,7 @@
 #include "chassis_test_auto_drive_command.hpp"
 
-using src::communication::cv::CVSerialData;
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/errors/create_errors.hpp"
 
 namespace control
 {

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
@@ -1,0 +1,50 @@
+#ifndef CHASSIS_AUTO_DRIVE_COMMAND_HPP_
+#define CHASSIS_AUTO_DRIVE_COMMAND_HPP_
+
+#include "tap/control/command.hpp"
+
+#include "chassis_subsystem.hpp"
+#include "control/drivers/drivers.hpp"
+
+namespace control
+{
+namespace chassis
+{
+class ChassisTestAutoDriveCommand : public tap::control::Command
+{
+public:
+    /**
+     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * be nullptr.
+     *
+     * @param[in] chassis a pointer to the chassis to be passed in that this
+     *      Command will interact with.
+     */
+    ChassisTestAutoDriveCommand(ChassisSubsystem *const chassis, src::Drivers *drivers);
+
+    ChassisTestAutoDriveCommand(const ChassisTestAutoDriveCommand &other) = delete;
+
+    ChassisTestAutoDriveCommand &operator=(const ChassisTestAutoDriveCommand &other) = delete;
+
+    void initialize() override;
+
+    const char *getName() const { return "chassis auto drive command"; }
+
+    void execute() override;
+
+    void end(bool) override;
+
+    bool isFinished() const override;
+
+private:
+    ChassisSubsystem *const chassis;
+
+    src::Drivers *drivers;
+};  // ChassisAutoDriveCommand
+
+}  // namespace chassis
+
+}  // namespace control
+
+#endif  // CHASSIS_AUTO_DRIVE_COMMAND_HPP_
+

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
@@ -1,10 +1,6 @@
 #ifndef CHASSIS_TEST_AUTO_DRIVE_COMMAND_HPP_
 #define CHASSIS_TEST_AUTO_DRIVE_COMMAND_HPP_
 
-#include "tap/control/command.hpp"
-
-#include "chassis_subsystem.hpp"
-#include "control/drivers/drivers.hpp"
 #include "generic_auto_drive_command.hpp"
 
 namespace control

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/chassis_test_auto_drive_command.hpp
@@ -1,16 +1,17 @@
-#ifndef CHASSIS_AUTO_DRIVE_COMMAND_HPP_
-#define CHASSIS_AUTO_DRIVE_COMMAND_HPP_
+#ifndef CHASSIS_TEST_AUTO_DRIVE_COMMAND_HPP_
+#define CHASSIS_TEST_AUTO_DRIVE_COMMAND_HPP_
 
 #include "tap/control/command.hpp"
 
 #include "chassis_subsystem.hpp"
 #include "control/drivers/drivers.hpp"
+#include "generic_auto_drive_command.hpp"
 
 namespace control
 {
 namespace chassis
 {
-class ChassisTestAutoDriveCommand : public tap::control::Command
+class ChassisTestAutoDriveCommand : public GenericAutoDriveCommand
 {
 public:
     /**
@@ -26,25 +27,14 @@ public:
 
     ChassisTestAutoDriveCommand &operator=(const ChassisTestAutoDriveCommand &other) = delete;
 
-    void initialize() override;
-
-    const char *getName() const { return "chassis auto drive command"; }
+    const char* getName() const { return "chassis test auto drive command"; }
 
     void execute() override;
-
-    void end(bool) override;
-
-    bool isFinished() const override;
-
-private:
-    ChassisSubsystem *const chassis;
-
-    src::Drivers *drivers;
-};  // ChassisAutoDriveCommand
+};  // ChassisTestAutoDriveCommand
 
 }  // namespace chassis
 
 }  // namespace control
 
-#endif  // CHASSIS_AUTO_DRIVE_COMMAND_HPP_
+#endif  // CHASSIS_TEST_AUTO_DRIVE_COMMAND_HPP_
 

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/generic_auto_drive_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/generic_auto_drive_command.cpp
@@ -1,0 +1,45 @@
+#include "generic_auto_drive_command.hpp"
+
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/errors/create_errors.hpp"
+
+using src::communication::cv::CVSerialData;
+
+namespace control
+{
+namespace chassis
+{
+GenericAutoDriveCommand::GenericAutoDriveCommand(
+    ChassisSubsystem *const chassis,
+    src::Drivers *drivers)
+    : chassis(chassis),
+      drivers(drivers)
+{
+    if (chassis == nullptr)
+    {
+        return;
+    }
+    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(chassis));
+}
+
+void  GenericAutoDriveCommand::initialize() {}
+
+void  GenericAutoDriveCommand::execute()
+{
+    // Acquire setpoints received from CV over serial through CVHandler
+    // And convert velocities to chassis inputs
+    CVSerialData::Rx::MovementData movementData = drivers->cvHandler.getMovementData();
+    float x = movementData.xSetpoint*VX_TO_X;
+    float y = movementData.ySetpoint*VY_TO_Y;
+    float r = movementData.rSetpoint*W_TO_R;
+    chassis->setTargetOutput(x,y,r);
+}
+
+void  GenericAutoDriveCommand::end(bool) {
+    chassis->setTargetOutput(0,0,0);
+}
+
+bool  GenericAutoDriveCommand::isFinished() const { return false; }
+}  // namespace chassis
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/chassis/generic_auto_drive_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/chassis/generic_auto_drive_command.hpp
@@ -1,0 +1,48 @@
+#ifndef GENERIC_AUTO_DRIVE_COMMAND_HPP_
+#define GENERIC_AUTO_DRIVE_COMMAND_HPP_
+
+#include "tap/control/command.hpp"
+
+#include "chassis_subsystem.hpp"
+#include "control/drivers/drivers.hpp"
+
+namespace control
+{
+namespace chassis
+{
+class GenericAutoDriveCommand : public tap::control::Command
+{
+public:
+    /**
+     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * be nullptr.
+     *
+     * @param[in] chassis a pointer to the chassis to be passed in that this
+     *      Command will interact with.
+     */
+    GenericAutoDriveCommand(ChassisSubsystem *const chassis, src::Drivers *drivers);
+
+    GenericAutoDriveCommand(const GenericAutoDriveCommand &other) = delete;
+
+    GenericAutoDriveCommand &operator=(const GenericAutoDriveCommand &other) = delete;
+
+    void initialize() override;
+
+    virtual void execute() override;
+
+    void end(bool) override;
+
+    bool isFinished() const override;
+
+protected:
+    ChassisSubsystem *const chassis;
+    
+    src::Drivers *drivers;
+};  // GenericAutoDriveCommand
+
+}  // namespace chassis
+
+}  // namespace control
+
+#endif  // GENERIC_AUTO_DRIVE_COMMAND_HPP_
+

--- a/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.cpp
@@ -1,0 +1,45 @@
+#include "generic_auto_aim_command.hpp"
+
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/errors/create_errors.hpp"
+
+using src::communication::cv::CVSerialData;
+
+namespace control
+{
+namespace turret
+{
+GenericAutoAimCommand::GenericAutoAimCommand(
+    TurretSubsystem *const turret,
+    src::Drivers *drivers)
+    : turret(turret),
+      drivers(drivers)
+{
+    if (turret == nullptr)
+    {
+        return;
+    }
+    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(turret));
+}
+
+void  GenericAutoAimCommand::initialize() {}
+
+void  GenericAutoAimCommand::execute()
+{
+    // Acquire setpoints received from CV over serial through CVHandler
+    CVSerialData::Rx::TurretData turretData = drivers->cvHandler.getTurretData();
+    float pitchSetpoint = turretData.pitchSetpoint*MRAD_TO_DEGREES;
+    float yawSetpoint = turretData.yawSetpoint*MRAD_TO_DEGREES;
+
+    turret->setAbsoluteOutputDegrees(yawSetpoint, pitchSetpoint);
+}
+
+void  GenericAutoAimCommand::end(bool) {
+    // Do nothing when switching back to manual aim, 
+    // ie leave current setpoints where they are.
+}
+
+bool  GenericAutoAimCommand::isFinished() const { return false; }
+}  // namespace turret
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.hpp
@@ -14,7 +14,7 @@ class GenericAutoAimCommand : public tap::control::Command
 {
 public:
     /**
-     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * Initializes the command with the passed in TurretSubsystem.  Must not
      * be nullptr.
      *
      * @param[in] turret a pointer to the chassis to be passed in that this

--- a/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/generic_auto_aim_command.hpp
@@ -1,0 +1,51 @@
+#ifndef GENERIC_AUTO_AIM_COMMAND_HPP_
+#define GENERIC_AUTO_AIM_COMMAND_HPP_
+
+#include "tap/control/command.hpp"
+
+#include "turret_subsystem.hpp"
+#include "control/drivers/drivers.hpp"
+
+namespace control
+{
+namespace turret
+{
+class GenericAutoAimCommand : public tap::control::Command
+{
+public:
+    /**
+     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * be nullptr.
+     *
+     * @param[in] turret a pointer to the chassis to be passed in that this
+     *      Command will interact with.
+     */
+    GenericAutoAimCommand(TurretSubsystem *const turret, src::Drivers *drivers);
+
+    GenericAutoAimCommand(const GenericAutoAimCommand &other) = delete;
+
+    GenericAutoAimCommand &operator=(const GenericAutoAimCommand &other) = delete;
+
+    void initialize() override;
+
+    virtual void execute() override;
+
+    void end(bool) override;
+
+    bool isFinished() const override;
+
+protected:
+    TurretSubsystem *const turret;
+
+    src::Drivers *drivers;
+
+    const float MRAD_TO_DEGREES = 0.0572958;
+
+};  // GenericAutoAimCommand
+
+}  // namespace turret
+
+}  // namespace control
+
+#endif  // GENERIC_AUTO_AIM_COMMAND_HPP_
+

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
@@ -26,6 +26,11 @@ void  TurretAutoAimCommand::initialize() {}
 
 void  TurretAutoAimCommand::execute()
 {
+    if (!IS_IN_TESTING && drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
+    {
+        turret->setAbsoluteOutputDegrees(turret->getYawNeutralPos(), turret->getPitchNeutralPos());
+        return;
+    }
     // Acquire setpoints received from CV over serial through CVHandler
     CVSerialData::Rx::TurretData turretData = drivers->cvHandler.getTurretData();
     float pitchSetpoint = turretData.pitchSetpoint*MRAD_TO_DEGREES;

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
@@ -12,17 +12,9 @@ namespace turret
 TurretAutoAimCommand::TurretAutoAimCommand(
     TurretSubsystem *const turret,
     src::Drivers *drivers)
-    : turret(turret),
-      drivers(drivers)
+    : GenericAutoAimCommand(turret, drivers)
 {
-    if (turret == nullptr)
-    {
-        return;
-    }
-    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(turret));
 }
-
-void  TurretAutoAimCommand::initialize() {}
 
 void  TurretAutoAimCommand::execute()
 {
@@ -32,19 +24,8 @@ void  TurretAutoAimCommand::execute()
         return;
     }
     // Acquire setpoints received from CV over serial through CVHandler
-    CVSerialData::Rx::TurretData turretData = drivers->cvHandler.getTurretData();
-    float pitchSetpoint = turretData.pitchSetpoint*MRAD_TO_DEGREES;
-    float yawSetpoint = turretData.yawSetpoint*MRAD_TO_DEGREES;
-
-    turret->setAbsoluteOutputDegrees(yawSetpoint, pitchSetpoint);
+    GenericAutoAimCommand::execute();
 }
-
-void  TurretAutoAimCommand::end(bool) {
-    // Do nothing when switching back to manual aim, 
-    // ie leave current setpoints where they are.
-}
-
-bool  TurretAutoAimCommand::isFinished() const { return false; }
 }  // namespace turret
 }  // namespace control
 

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
@@ -26,7 +26,7 @@ void  TurretAutoAimCommand::initialize() {}
 
 void  TurretAutoAimCommand::execute()
 {
-    if (!IS_IN_TESTING && drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
+    if (drivers->refSerial.getGameData().gameStage != tap::communication::serial::RefSerialData::Rx::GameStage::IN_GAME)
     {
         turret->setAbsoluteOutputDegrees(turret->getYawNeutralPos(), turret->getPitchNeutralPos());
         return;

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.cpp
@@ -3,8 +3,6 @@
 #include "tap/algorithms/math_user_utils.hpp"
 #include "tap/errors/create_errors.hpp"
 
-using src::communication::cv::CVSerialData;
-
 namespace control
 {
 namespace turret

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.hpp
@@ -1,16 +1,13 @@
 #ifndef TURRET_AUTO_AIM_COMMAND_HPP_
 #define TURRET_AUTO_AIM_COMMAND_HPP_
 
-#include "tap/control/command.hpp"
-
-#include "turret_subsystem.hpp"
-#include "control/drivers/drivers.hpp"
+#include "generic_auto_aim_command.hpp"
 
 namespace control
 {
 namespace turret
 {
-class TurretAutoAimCommand : public tap::control::Command
+class TurretAutoAimCommand : public GenericAutoAimCommand
 {
 public:
     /**
@@ -26,22 +23,9 @@ public:
 
     TurretAutoAimCommand &operator=(const TurretAutoAimCommand &other) = delete;
 
-    void initialize() override;
-
     const char *getName() const { return "turret auto aim command"; }
 
     void execute() override;
-
-    void end(bool) override;
-
-    bool isFinished() const override;
-
-private:
-    TurretSubsystem *const turret;
-
-    src::Drivers *drivers;
-
-    const float MRAD_TO_DEGREES = 0.0572958;
 
 };  // TurretAutoAimCommand
 

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_auto_aim_command.hpp
@@ -11,7 +11,7 @@ class TurretAutoAimCommand : public GenericAutoAimCommand
 {
 public:
     /**
-     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * Initializes the command with the passed in TurretSubsystem.  Must not
      * be nullptr.
      *
      * @param[in] turret a pointer to the chassis to be passed in that this

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
@@ -1,0 +1,45 @@
+#include "turret_test_auto_aim_command.hpp"
+
+#include "tap/algorithms/math_user_utils.hpp"
+#include "tap/errors/create_errors.hpp"
+
+using src::communication::cv::CVSerialData;
+
+namespace control
+{
+namespace turret
+{
+TurretTestAutoAimCommand::TurretTestAutoAimCommand(
+    TurretSubsystem *const turret,
+    src::Drivers *drivers)
+    : turret(turret),
+      drivers(drivers)
+{
+    if (turret == nullptr)
+    {
+        return;
+    }
+    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(turret));
+}
+
+void  TurretTestAutoAimCommand::initialize() {}
+
+void  TurretTestAutoAimCommand::execute()
+{
+    // Acquire setpoints received from CV over serial through CVHandler
+    CVSerialData::Rx::TurretData turretData = drivers->cvHandler.getTurretData();
+    float pitchSetpoint = turretData.pitchSetpoint*MRAD_TO_DEGREES;
+    float yawSetpoint = turretData.yawSetpoint*MRAD_TO_DEGREES;
+
+    turret->setAbsoluteOutputDegrees(yawSetpoint, pitchSetpoint);
+}
+
+void  TurretTestAutoAimCommand::end(bool) {
+    // Do nothing when switching back to manual aim, 
+    // ie leave current setpoints where they are.
+}
+
+bool  TurretTestAutoAimCommand::isFinished() const { return false; }
+}  // namespace turret
+}  // namespace control
+

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
@@ -12,17 +12,9 @@ namespace turret
 TurretTestAutoAimCommand::TurretTestAutoAimCommand(
     TurretSubsystem *const turret,
     src::Drivers *drivers)
-    : turret(turret),
-      drivers(drivers)
+    : GenericAutoAimCommand(turret, drivers)
 {
-    if (turret == nullptr)
-    {
-        return;
-    }
-    this->addSubsystemRequirement(dynamic_cast<tap::control::Subsystem *>(turret));
 }
-
-void  TurretTestAutoAimCommand::initialize() {}
 
 void  TurretTestAutoAimCommand::execute()
 {
@@ -33,13 +25,6 @@ void  TurretTestAutoAimCommand::execute()
 
     turret->setAbsoluteOutputDegrees(yawSetpoint, pitchSetpoint);
 }
-
-void  TurretTestAutoAimCommand::end(bool) {
-    // Do nothing when switching back to manual aim, 
-    // ie leave current setpoints where they are.
-}
-
-bool  TurretTestAutoAimCommand::isFinished() const { return false; }
 }  // namespace turret
 }  // namespace control
 

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.cpp
@@ -3,8 +3,6 @@
 #include "tap/algorithms/math_user_utils.hpp"
 #include "tap/errors/create_errors.hpp"
 
-using src::communication::cv::CVSerialData;
-
 namespace control
 {
 namespace turret
@@ -18,12 +16,7 @@ TurretTestAutoAimCommand::TurretTestAutoAimCommand(
 
 void  TurretTestAutoAimCommand::execute()
 {
-    // Acquire setpoints received from CV over serial through CVHandler
-    CVSerialData::Rx::TurretData turretData = drivers->cvHandler.getTurretData();
-    float pitchSetpoint = turretData.pitchSetpoint*MRAD_TO_DEGREES;
-    float yawSetpoint = turretData.yawSetpoint*MRAD_TO_DEGREES;
-
-    turret->setAbsoluteOutputDegrees(yawSetpoint, pitchSetpoint);
+    GenericAutoAimCommand::execute();
 }
 }  // namespace turret
 }  // namespace control

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
@@ -11,7 +11,7 @@ class TurretTestAutoAimCommand : public GenericAutoAimCommand
 {
 public:
     /**
-     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * Initializes the command with the passed in TurretSubsystem.  Must not
      * be nullptr.
      *
      * @param[in] turret a pointer to the chassis to be passed in that this

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
@@ -1,0 +1,53 @@
+#ifndef TURRET_AUTO_AIM_COMMAND_HPP_
+#define TURRET_AUTO_AIM_COMMAND_HPP_
+
+#include "tap/control/command.hpp"
+
+#include "turret_subsystem.hpp"
+#include "control/drivers/drivers.hpp"
+
+namespace control
+{
+namespace turret
+{
+class TurretTestAutoAimCommand : public tap::control::Command
+{
+public:
+    /**
+     * Initializes the command with the passed in ChassisSubsystem.  Must not
+     * be nullptr.
+     *
+     * @param[in] turret a pointer to the chassis to be passed in that this
+     *      Command will interact with.
+     */
+    TurretTestAutoAimCommand(TurretSubsystem *const turret, src::Drivers *drivers);
+
+    TurretTestAutoAimCommand(const TurretTestAutoAimCommand &other) = delete;
+
+    TurretTestAutoAimCommand &operator=(const TurretTestAutoAimCommand &other) = delete;
+
+    void initialize() override;
+
+    const char *getName() const { return "turret auto aim command"; }
+
+    void execute() override;
+
+    void end(bool) override;
+
+    bool isFinished() const override;
+
+private:
+    TurretSubsystem *const turret;
+
+    src::Drivers *drivers;
+
+    const float MRAD_TO_DEGREES = 0.0572958;
+
+};  // TurretTestAutoAimCommand
+
+}  // namespace turret
+
+}  // namespace control
+
+#endif  // TURRET_AUTO_AIM_COMMAND_HPP_
+

--- a/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/turret/turret_test_auto_aim_command.hpp
@@ -1,16 +1,13 @@
-#ifndef TURRET_AUTO_AIM_COMMAND_HPP_
-#define TURRET_AUTO_AIM_COMMAND_HPP_
+#ifndef TURRET_TEST_AUTO_AIM_COMMAND_HPP_
+#define TURRET_TEST_AUTO_AIM_COMMAND_HPP_
 
-#include "tap/control/command.hpp"
-
-#include "turret_subsystem.hpp"
-#include "control/drivers/drivers.hpp"
+#include "generic_auto_aim_command.hpp"
 
 namespace control
 {
 namespace turret
 {
-class TurretTestAutoAimCommand : public tap::control::Command
+class TurretTestAutoAimCommand : public GenericAutoAimCommand
 {
 public:
     /**
@@ -26,22 +23,9 @@ public:
 
     TurretTestAutoAimCommand &operator=(const TurretTestAutoAimCommand &other) = delete;
 
-    void initialize() override;
-
-    const char *getName() const { return "turret auto aim command"; }
+    const char *getName() const { return "turret test auto aim command"; }
 
     void execute() override;
-
-    void end(bool) override;
-
-    bool isFinished() const override;
-
-private:
-    TurretSubsystem *const turret;
-
-    src::Drivers *drivers;
-
-    const float MRAD_TO_DEGREES = 0.0572958;
 
 };  // TurretTestAutoAimCommand
 
@@ -49,5 +33,5 @@ private:
 
 }  // namespace control
 
-#endif  // TURRET_AUTO_AIM_COMMAND_HPP_
+#endif  // TURRET_TEST_AUTO_AIM_COMMAND_HPP_
 

--- a/PolySTAR-Taproot-project/taproot/src/tap/util_macros.hpp
+++ b/PolySTAR-Taproot-project/taproot/src/tap/util_macros.hpp
@@ -42,6 +42,4 @@
 
 #define UNUSED(var) (void)(var)
 
-#define IS_IN_TESTING true
-
 #endif  // TAPROOT_UTIL_MACROS_HPP_

--- a/PolySTAR-Taproot-project/taproot/src/tap/util_macros.hpp
+++ b/PolySTAR-Taproot-project/taproot/src/tap/util_macros.hpp
@@ -42,4 +42,6 @@
 
 #define UNUSED(var) (void)(var)
 
+#define IS_IN_TESTING true
+
 #endif  // TAPROOT_UTIL_MACROS_HPP_


### PR DESCRIPTION
Adding verification to the execute method of auto commands to make them wait until the game stage is in game. Creating new test commands that doesn't need referee feedback. Unmap previous mapping and mapping those new commands. & Instanciate turret Auto Aim command in ICRA.