### PR TITLE
Update snail class

### DIFF
--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.cpp
@@ -17,7 +17,7 @@ SnailMotor::SnailMotor(
 }
 
 void SnailMotor::init() {
-    drivers->pwm.setTimerFrequency(tap::gpio::Pwm::Timer::TIMER8, 400);
+    drivers->pwm.setTimerFrequency(tap::gpio::Pwm::Timer::TIMER8, PWM_FREQUENCY); // Timer 8 controls pins W-Z on Board A
     drivers->pwm.write(THROTTLE_IDLE, pwmPin);
 }
 

--- a/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
+++ b/PolySTAR-Taproot-project/src/subsystems/flywheel/snail_motor.hpp
@@ -9,26 +9,28 @@ namespace src
 namespace motor
 {
 /**
- * This class wraps around the Servo class to provide utilities for controlling a Robomaster Snail motor.
+ * This class provides functionality for snail motors using the C615 ESC
  */
 class SnailMotor
 {
 public:
     /**
-     * Initializes the Snail PWM and associates the motor with some PWM pin.
-     * THIS WILL ONLY WORK IF PWM IS SET TO 500Hz OR LESS (see snail esc datasheet)
+     * Constructs the snail motor object and associates the motor with some PWM pin.
      *
-     * @param[in] drivers Instance to the drivers class you would like to use.
-     * @param[in] pwmPin The pin to attach the Snail Motor class with.
+     * @param[in] drivers Instance to the drivers class.
+     * @param[in] pwmPin PWM pin connected to the C615 ESC. Valid pins are W, X, Y, and Z.
      */
     SnailMotor(
         tap::Drivers *drivers,
         tap::gpio::Pwm::Pin pwmPin);
 
+    /**
+     * Initializes timer frequency and sets the throttle to idle.
+     */
     void init();
 
     /**
-     * Sets the throttle value sent to the Snail ESC.
+     * Sets the throttle value sent to ESC.
      * 0-1, where 0 is idle and 1 is full throttle
      */
     void setThrottle(float throttle);
@@ -36,16 +38,20 @@ public:
 private:
     tap::Drivers *drivers;
 
-    /// The PWM pin that the servo is attached to.
+    /// The PWM pin that the motor is attached to. Valid pins are W, X, Y, and Z.
     tap::gpio::Pwm::Pin pwmPin;
 
-    // Duty cycle values for pulse widths
-    // Idle throttle 1ms -> 50% duty cycle at 500Hz
-    // Full throttle 2ms -> 100% duty cycle at 500Hz
-    const float THROTTLE_IDLE = 0.16;
-    const float THROTTLE_MAX = 0.88;
-    const float THROTTLE_RANGE = THROTTLE_MAX - THROTTLE_IDLE;
+    // Pulse widths in milliseconds
+    const float MIN_PULSE_MS = 1;
+    const float MAX_PULSE_MS = 2;
+    
+    // PWM frequency in Hz (Max 500Hz, see C615 datasheet)
+    // Must be set below 500Hz (2ms pulse at 500 Hz is 100% duty cycle, which the esc reads as a constant signal and causes error)
+    const uint32_t PWM_FREQUENCY = 400;
 
+    // Pulse widths converted to duty cycle
+    const float THROTTLE_IDLE = MIN_PULSE_MS*PWM_FREQUENCY*0.001f;
+    const float THROTTLE_RANGE = (MAX_PULSE_MS - MIN_PULSE_MS)*PWM_FREQUENCY*0.001f;
 
 };  // class SnailMotor
 


### PR DESCRIPTION
_**BUILDS SUCCESSFULLY BUT NOT TESTED ON ROBOT YET. RECOMMEND DOING THAT BEFORE MERGING.**_

Changes :
- Add attribute for PWM frequency
- Add attribute for pulse width
- Automatically calculate duty cycles from frequency and pulse widths
- Update/add comments for clarity

Notes :
- We might want to move the `MAX_PULSE_MS`, `MIN_PULSE_MS` and `PWM_FREQUENCY` attributes to `flywheel_constants.hpp` and put them in the constructor, and calculate the duty cycles and range during `init()`.
- This assumes that the minimum pulse width is 1ms and the maximum is 2ms, but this will depend on how the ESCs are currently configured. Recommend redoing configuration on all the ESCs (see below) to make sure they are all set to the same range. (Mismatches in configuration / pulse ranges would explain the odd behavior we've been having lately with the flywheels)

From [C615 USER Guide](https://rm-static.djicdn.com/tem/17348/RoboMaster%20C615%20Brushless%20DC%20Motor%20Speed%20Controller%20User%20Guide.pdf) :
![image](https://github.com/PolySTAR-mtl/PolySTAR-Taproot/assets/75456969/59c1a163-e187-4d61-86fd-b4c28a256f3e)